### PR TITLE
Migrate GitGitGadget to GitHub Actions

### DIFF
--- a/.github/workflows/handle-new-mails.yml
+++ b/.github/workflows/handle-new-mails.yml
@@ -4,6 +4,9 @@ on:
   # GitGitGadget's GitHub App is expected to trigger this on `git-mailing-list-mirror` updates
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   handle-new-mails:
     runs-on: ubuntu-latest

--- a/.github/workflows/handle-new-mails.yml
+++ b/.github/workflows/handle-new-mails.yml
@@ -1,0 +1,37 @@
+name: Handle new mails
+
+on:
+  # GitGitGadget's GitHub App is expected to trigger this on `git-mailing-list-mirror` updates
+  workflow_dispatch:
+
+jobs:
+  handle-new-mails:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/create-github-app-token@v1
+      id: gitgitgadget-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
+        owner: gitgitgadget
+        repositories: git
+    - uses: actions/create-github-app-token@v1
+      id: git-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
+        owner: git
+        repositories: git
+    - uses: actions/create-github-app-token@v1
+      id: dscho-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
+        owner: dscho
+        repositories: git
+    - uses: gitgitgadget/gitgitgadget/handle-new-mails@v1
+      with:
+        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
+        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
+        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -1,0 +1,50 @@
+name: Handle a PR comment
+run-name: Handle slash command in a PR comment`
+
+on:
+  # GitGitGadget's GitHub App is expected to trigger this on `issue_comment` events
+  # that have the `action` set to `created` or `edited`
+  workflow_dispatch:
+    inputs:
+      pr-comment-url:
+        description: 'URL of the PR comment to handle'
+        required: true
+
+env:
+  PR_COMMENT_URL: ${{ inputs.pr-comment-url }}
+
+jobs:
+  handle-pr-comment:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/create-github-app-token@v1
+      id: gitgitgadget-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
+        owner: gitgitgadget
+        repositories: git
+    - uses: actions/create-github-app-token@v1
+      id: git-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
+        owner: git
+        repositories: git
+    - uses: actions/create-github-app-token@v1
+      id: dscho-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
+        owner: dscho
+        repositories: git
+    - uses: gitgitgadget/gitgitgadget/handle-pr-comment@v1
+      with:
+        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
+        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
+        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
+        smtp-host: smtp.gmail.com
+        smtp-user: gitgitgadget@gmail.com
+        smtp-pass: "${{ secrets.GITGITGADGET_SMTP_PASS }}"
+        pr-comment-url: ${{ env.PR_COMMENT_URL }}

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -13,6 +13,9 @@ on:
 env:
   PR_COMMENT_URL: ${{ inputs.pr-comment-url }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr-comment-url }}
+
 jobs:
   handle-pr-comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -39,6 +39,43 @@ jobs:
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
         owner: dscho
         repositories: git
+    - name: create a check run
+      id: create-check-run
+      run: |
+        title="Handle PR comment"
+        summary="Handling PR comment $PR_COMMENT_URL"
+        details_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        text="This handles $PR_COMMENT_URL, see $details_url for details."
+        echo "title=$title" >> $GITHUB_OUTPUT
+        echo "summary=$summary" >> $GITHUB_OUTPUT
+        echo "text=$text" >> $GITHUB_OUTPUT
+
+        PR_NUMBER="${PR_COMMENT_URL%#*}" # skip the suffix with the comment ID
+        PR_NUMBER="${PR_NUMBER##*/}" # skip the prefix before the PR number
+
+        export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+        eval "$(gh api repos/gitgitgadget/git/pulls/$PR_NUMBER \
+          --jq '"head_sha=\(.head.sha) && repo=\(.base.repo.full_name)"')"
+        echo "head_sha=$head_sha" >> $GITHUB_OUTPUT
+        echo "repo=$repo" >> $GITHUB_OUTPUT
+
+        export GH_TOKEN="$(case "$repo" in
+          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
+          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          *) echo "${{ secrets.GITHUB_TOKEN }}";;
+          esac
+        )"
+        eval "$(gh api repos/$repo/check-runs -X POST \
+          -f name='handle_pr_comment' \
+          -f head_sha="$head_sha" \
+          -f status='in_progress' \
+          -f details_url="$details_url" \
+          -f "output[title]=$title" \
+          -f "output[summary]=$summary" \
+          -f "output[text]=$text" \
+          --jq '"check_run_id=\(.id)"')"
+        echo "check_run_id=$check_run_id" >> $GITHUB_OUTPUT
     - uses: gitgitgadget/gitgitgadget/handle-pr-comment@v1
       with:
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
@@ -48,3 +85,20 @@ jobs:
         smtp-user: gitgitgadget@gmail.com
         smtp-pass: "${{ secrets.GITGITGADGET_SMTP_PASS }}"
         pr-comment-url: ${{ env.PR_COMMENT_URL }}
+    - name: update the check run
+      if: always() && steps.create-check-run.outputs.check_run_id != ''
+      run: |
+        export GH_TOKEN="$(case "${{ steps.create-check-run.outputs.repo }}" in
+          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
+          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          *) echo "${{ secrets.GITHUB_TOKEN }}";;
+          esac
+        )"
+        gh api repos/${{ steps.create-check-run.outputs.repo }}/check-runs/${{ steps.create-check-run.outputs.check_run_id }} \
+          -X PATCH \
+          -f status='completed' \
+          -f conclusion='${{ job.status }}' \
+          -f 'output[title]=${{ steps.create-check-run.outputs.title }}' \
+          -f 'output[summary]=${{ steps.create-check-run.outputs.summary }}' \
+          -f 'output[text]=${{ steps.create-check-run.outputs.text }}'

--- a/.github/workflows/handle-pr-push.yml
+++ b/.github/workflows/handle-pr-push.yml
@@ -1,0 +1,47 @@
+name: Handle pushes to PRs
+run-name: Check and validate commits pushed to a PR
+
+on:
+  # GitGitGadget's GitHub App is expected to trigger this on `pull_request` events
+  # that have the `action` set to `opened` or `synchronize`
+  workflow_dispatch:
+    inputs:
+      pr-url:
+        description: 'URL of the PR to handle'
+        required: true
+
+env:
+  PR_URL: ${{ inputs.pr-url }}
+
+jobs:
+  handle-pr-push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/create-github-app-token@v1
+      id: gitgitgadget-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
+        owner: gitgitgadget
+        repositories: git
+    - uses: actions/create-github-app-token@v1
+      id: git-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
+        owner: git
+        repositories: git
+    - uses: actions/create-github-app-token@v1
+      id: dscho-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
+        owner: dscho
+        repositories: git
+    - uses: gitgitgadget/gitgitgadget/handle-pr-push@v1
+      with:
+        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
+        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
+        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
+        pr-url: ${{ env.PR_URL }}

--- a/.github/workflows/handle-pr-push.yml
+++ b/.github/workflows/handle-pr-push.yml
@@ -13,6 +13,9 @@ on:
 env:
   PR_URL: ${{ inputs.pr-url }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr-url }}
+
 jobs:
   handle-pr-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/handle-pr-push.yml
+++ b/.github/workflows/handle-pr-push.yml
@@ -39,9 +39,62 @@ jobs:
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
         owner: dscho
         repositories: git
+    - name: create a check run
+      id: create-check-run
+      run: |
+        title="Handle PR push"
+        summary="Handling new commits in $PR_URL"
+        details_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        text="This handles $PR_URL, see $details_url for details."
+        echo "title=$title" >> $GITHUB_OUTPUT
+        echo "summary=$summary" >> $GITHUB_OUTPUT
+        echo "text=$text" >> $GITHUB_OUTPUT
+
+        PR_NUMBER="${PR_URL##*/}" # skip the prefix before the PR number
+
+        export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+        eval "$(gh api repos/gitgitgadget/git/pulls/$PR_NUMBER \
+          --jq '"head_sha=\(.head.sha) && repo=\(.base.repo.full_name)"')"
+        echo "head_sha=$head_sha" >> $GITHUB_OUTPUT
+        echo "repo=$repo" >> $GITHUB_OUTPUT
+
+        export GH_TOKEN="$(case "$repo" in
+          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
+          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          *) echo "${{ secrets.GITHUB_TOKEN }}";;
+          esac
+        )"
+        eval "$(gh api repos/$repo/check-runs -X POST \
+          -f name='handle_pr_push' \
+          -f head_sha="$head_sha" \
+          -f status='in_progress' \
+          -f details_url="$details_url" \
+          -f "output[title]=$title" \
+          -f "output[summary]=$summary" \
+          -f "output[text]=$text" \
+          --jq '"check_run_id=\(.id)"')"
+        echo "check_run_id=$check_run_id" >> $GITHUB_OUTPUT
     - uses: gitgitgadget/gitgitgadget/handle-pr-push@v1
       with:
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
         upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
         test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
         pr-url: ${{ env.PR_URL }}
+    - name: update the check run
+      if: always() && steps.create-check-run.outputs.check_run_id != ''
+      run: |
+        export GH_TOKEN="$(case "${{ steps.create-check-run.outputs.repo }}" in
+          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
+          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          *) echo "${{ secrets.GITHUB_TOKEN }}";;
+          esac
+        )"
+        gh api repos/${{ steps.create-check-run.outputs.repo }}/check-runs/${{ steps.create-check-run.outputs.check_run_id }} \
+          -X PATCH \
+          -f status='completed' \
+          -f conclusion='${{ job.status }}' \
+          -f 'output[title]=${{ steps.create-check-run.outputs.title }}' \
+          -f 'output[summary]=${{ steps.create-check-run.outputs.summary }}' \
+          -f 'output[text]=${{ steps.create-check-run.outputs.text }}'

--- a/.github/workflows/update-mail-to-commit-notes.yml
+++ b/.github/workflows/update-mail-to-commit-notes.yml
@@ -1,0 +1,22 @@
+name: Update Mail to Commit Notes
+run-name: Update the `mail-to-commit` and `commit-to-mail` Git notes
+
+on:
+  # GitGitGadget's GitHub App is expected to trigger this on `seen` updates
+  workflow_dispatch:
+
+jobs:
+  update-mail-to-commit-notes:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/create-github-app-token@v1
+      id: gitgitgadget-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
+        owner: gitgitgadget
+        repositories: git
+    - uses: gitgitgadget/gitgitgadget/update-mail-to-commit-notes@v1
+      with:
+        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}

--- a/.github/workflows/update-mail-to-commit-notes.yml
+++ b/.github/workflows/update-mail-to-commit-notes.yml
@@ -5,6 +5,9 @@ on:
   # GitGitGadget's GitHub App is expected to trigger this on `seen` updates
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   update-mail-to-commit-notes:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -1,0 +1,37 @@
+name: Update GitGitGadget's PRs
+
+on:
+  # GitGitGadget's GitHub App is expected to trigger this on `seen` updates
+  workflow_dispatch:
+
+jobs:
+  update-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/create-github-app-token@v1
+      id: gitgitgadget-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
+        owner: gitgitgadget
+        repositories: git
+    - uses: actions/create-github-app-token@v1
+      id: git-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
+        owner: git
+        repositories: git
+    - uses: actions/create-github-app-token@v1
+      id: dscho-git-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
+        owner: dscho
+        repositories: git
+    - uses: gitgitgadget/gitgitgadget/update-prs@v1
+      with:
+        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
+        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
+        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -4,6 +4,9 @@ on:
   # GitGitGadget's GitHub App is expected to trigger this on `seen` updates
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   update-prs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR is part 5 of addressing https://github.com/gitgitgadget/gitgitgadget/issues/609, and it is stacked on top of https://github.com/gitgitgadget/gitgitgadget/pull/1980, https://github.com/gitgitgadget/gitgitgadget/pull/1981, https://github.com/gitgitgadget/gitgitgadget/pull/1982, and https://github.com/gitgitgadget/gitgitgadget/pull/1983, therefore I will leave this in draft mode until those PRs are merged.

For each GitHub Actions added by those PRs, this here PR adds a corresponding, minimal GitHub workflow. These will need to be triggered via [GitGitGadget's existing GitHub App](https://github.com/gitgitgadget/gitgitgadget-github-app).

Since I was slightly worried about a time penalty incurred by switching from the persistent `gitgitgadget/git` and `gitgitgadget/git-mailing-list-mirror` clones in the Azure Pipelines to ephemeral, partial clones in the GitHub workflows, I have run these (mostly in dry-run mode, to avoid updates that would duplicate already-existing ones), for comparison with the existing Azure Pipelines:

| name | test run | Azure Pipeline run |
| - | - | - |
| `handle-pr-comment` | [55s](https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/actions/runs/17071575768) | [58s](https://dev.azure.com/gitgitgadget/git/_build/results?buildId=253421&view=results) |
| `handle-pr-push` | [44s](https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/actions/runs/17072740170) | [48s](https://dev.azure.com/gitgitgadget/git/_build/results?buildId=253639&view=results) |
| `handle-new-mails` | [2m6s](https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/actions/runs/17073355141) | [53s](https://dev.azure.com/gitgitgadget/git/_build/results?buildId=253679&view=results) |
| `update-prs` | [6m27s](https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/actions/runs/17080319086) | [4m23s](https://dev.azure.com/gitgitgadget/git/_build/results?buildId=253397) |
| `update-mail-to-commit-notes` | [2m9s](https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/actions/runs/17073488868) | [1m10s](https://dev.azure.com/gitgitgadget/git/_build/results?buildId=253398) |

_Caveat_: The timing comparisons are not exactly apples to apples, as I haven't paid full attention to start from the exact same preconditions (for example, the Git mailing list mirror repository contained more emails during the test runs than when the Azure Pipelines ran). In some cases, I even used different PRs because the actual expensive parts were in the setup phase, anyway, the PR-specific logic took a comparatively tiny fraction of the time. In any case, I was mostly interested in ballpark estimates, to gauge roughly how much of a penalty the transition will incur.

While it'd have been fantastic if e.g. the `handle-new-mails` job would not have taken twice as long as the corresponding Azure Pipeline run, we need to take that time with a grain of salt: The test run probably handled many more emails than the Azure Pipeline because I ["rewound" the state](https://github.com/dscho/gitgitgadget/commit/7468a6a9596aec40b5f43b7efb9df63e6115284f) so that more code paths would be exercised than the "oh hey, we're up to date" one.

Having said that, the GitGitGadget functionality where swiftness is most crucial is the one where users interact directly, i.e. PR pushes and comments. In those scenarios, it seems that the difference is relatively small.

Since `update-prs` and `update-mail-to-commit-notes` are to be triggered by updates to the `seen` branch, which [seem to be less than a dozen times per week](https://github.com/git/git/activity?ref=seen), those time differences do not worry me much.

The most concerning difference is that of `handle-new-emails`, which is to be triggered by updates to the `git-mailing-list-mirror` repository. Looking at the [monthly insights of that repository](https://github.com/gitgitgadget/git-mailing-list-mirror/pulse/monthly), the frequency seems to be roughly one update every 20 minutes _on average_. Which, during more active times, amounts to a lot more frequent updates. If it should turn out in practice that the workflow _does_, indeed, take around two minutes for every run, I'll need to dig in to figure out how to accelerate this. But then, the 2m6s run mentioned above [handled the "What's cooking" email](https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/actions/runs/17073355141/job/48408023331#step:2:837), and there is a 44s jump right before that which _may_ mean that there's a lot of inefficient Git object fetching going on ([getting and updating Git notes](https://github.com/gitgitgadget/gitgitgadget/blob/6b6f802da3830071cbce6a0ac950b93586a9ca64/lib/mail-archive-helper.ts#L99-L108) in a partial repository are usually individual roundtrips...).